### PR TITLE
Added PlayAndAwaitStream method to avoid crashes when stopping  before first frames received

### DIFF
--- a/StreamPlayerControl/WPF/StreamPlayerControl/StreamPlayerControl/StreamPlayerControl.xaml.cs
+++ b/StreamPlayerControl/WPF/StreamPlayerControl/StreamPlayerControl/StreamPlayerControl.xaml.cs
@@ -15,7 +15,7 @@ namespace WebEye
         {
             InitializeComponent();
 
-            Dispatcher.ShutdownStarted += HandleShutdownStarted; 
+            Dispatcher.ShutdownStarted += HandleShutdownStarted;
         }
 
         private StreamPlayerProxy _player;
@@ -55,6 +55,31 @@ namespace WebEye
 
             Player.Open(url);
             Player.Play();
+
+            IsPlaying = true;
+        }
+
+        /// <summary>
+        /// Plays and awaits the stream
+        /// </summary>
+        /// <param name="url">The url of a stream to play.</param>
+        /// <exception cref="ArgumentException">An invalid string is passed as an argument.</exception>
+        /// <exception cref="Win32Exception">Failed to load the FFmpeg facade dll.</exception>
+        /// <exception cref="StreamPlayerException">Failed to play the stream.</exception>
+        public void PlayAndAwaitStream(String url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentException();
+            }
+
+            if (IsPlaying)
+            {
+                Stop();
+            }
+
+            Player.Open(url);
+            Player.Play(true);
 
             IsPlaying = true;
         }


### PR DESCRIPTION
While testing an app using this component came across two problems.

1. Stop method. Application crashed with exception that couldn't be caught when method was called right after Start method.This whas discovered while swithing on/off on a slow computer. 
2. GetCurrentFrame method. Exception was thrown when we tried to get frame right after calling Start.

This was caused by using delegates to native code methods that were not synchronized with the managed code.
This is why I decided to use GetCurrentFrame exception to create this crude fix. I've created new method to maintain backward compatibility